### PR TITLE
fix: `attempt to index local 'cfg' (a nil value)` error removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Has live previews as you type in insert mode.
 https://github.com/user-attachments/assets/94179603-2f41-43ff-9e5f-6dc4f31dc02d
 
 ## Installation
-Lazy.nvim: `{ 'PartyWumpus/typst-concealer', config = function() require('typst-concealer').setup() end, event = "VeryLazy" },`
+Lazy.nvim: `{ 'PartyWumpus/typst-concealer', config = function() require('typst-concealer').setup{} end, event = "VeryLazy" },`
 
 ## Known issues / Todo list
 - It doesn't actually hide the text beneath multiline images properly, so sometimes it's visible (if >75 chars)


### PR DESCRIPTION
When you use the default config that's in the README, you get the following error:
```
Failed to run `config` for typst-concealer

.../share/nvim/lazy/typst-concealer/lua/typst-concealer.lua:831: attempt to index local 'cfg' (a nil value)

# stacktrace:
  - /typst-concealer/lua/typst-concealer.lua:831 _in_ **setup**
  - ~/.config/nvim/lua/tijme/plugins/all.lua:161 _in_ **config**
 ```
  
  I added an object for the plugin to recognize as the config. This removes the error. 