### PR TITLE
feat: support Neovim versions older than 0.10

### DIFF
--- a/lua/typst-concealer/init.lua
+++ b/lua/typst-concealer/init.lua
@@ -1,6 +1,8 @@
 --- @class typstconcealer
 local M = {}
 
+vim.uv = vim.uv or vim.loop
+
 local pngData = require('typst-concealer.png-lua')
 local kitty_codes = require('typst-concealer.kitty-codes')
 


### PR DESCRIPTION
I noticed that it uses `vim.uv`, which I happen to know is the new thing in 0.10. I also know that some plugins have a hack for it. So I looked it up and copied it over.

But I actually haven't tested it in older versions. If it's the only breaking change that needs patching then it should just work.
